### PR TITLE
ASA-5413: Adding Codesweep and SAST Github Action to repository

### DIFF
--- a/.github/workflows/codesweep.yml
+++ b/.github/workflows/codesweep.yml
@@ -1,0 +1,20 @@
+name: "HCL AppScan CodeSweep"
+on:
+  pull_request:
+    types: [opened,synchronize]
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Run AppScan CodeSweep
+        uses: HCL-TECH-SOFTWARE/appscan-codesweep-action@v2
+        with:
+          asoc_key: ${{secrets.ASOC_KEY}}
+          asoc_secret: ${{secrets.ASOC_SECRET}}
+          status: failure
+    env: 
+      GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/codesweep_publish.yml
+++ b/.github/workflows/codesweep_publish.yml
@@ -1,0 +1,18 @@
+name: "HCL AppScan CodeSweep Publish"
+on:
+  pull_request:
+    types: [closed]
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Publish issues to ASoC
+        uses: HCL-TECH-SOFTWARE/appscan-codesweep-action@v2
+        with:
+          asoc_key: ${{secrets.ASOC_KEY}}
+          asoc_secret: ${{secrets.ASOC_SECRET}}
+          publish_on_merge: true
+          application_id: e13159ff-a002-4b67-8c18-1132edcf8761
+          status: failure
+    env: 
+      GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/sast_github_action.yml
+++ b/.github/workflows/sast_github_action.yml
@@ -1,0 +1,15 @@
+name: "HCL AppScan SAST"
+on:
+  workflow_dispatch
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Run AppScan SAST scan
+        uses: HCL-TECH-SOFTWARE/appscan-sast-action@v1.0.1
+        with:
+          asoc_key: ${{secrets.ASOC_KEY}}
+          asoc_secret: ${{secrets.ASOC_SECRET}}
+          application_id: e13159ff-a002-4b67-8c18-1132edcf8761


### PR DESCRIPTION
Adding Codesweep and SAST Github Action to repository so that we can perform scans on every pull request and publish on every merge. SAST scan jobs can also now be kicked off manually by using the HCL AppScan SAST github action under Actions tab. Issues are submitted to ASoC.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

