### PR TITLE
Make dependency on YUI optional

### DIFF
--- a/src/main/resources/com/hcl/appscan/jenkins/plugin/builders/AppScanEnterpriseBuildStep/config.jelly
+++ b/src/main/resources/com/hcl/appscan/jenkins/plugin/builders/AppScanEnterpriseBuildStep/config.jelly
@@ -21,6 +21,7 @@
     <f:section title="${%label.job.properties}" field="loginTypeOptions">
 	    <f:entry title="${%label.template}" field="template">
 	        <f:textbox placeholder="${%template.placeholder}"
+             data-maxsuggestions="99999"
 	         style="background: white url('${resURL}${%search.icon.url}') no-repeat 99% center;
 	         background-size: 16px;" />
 	    </f:entry>
@@ -30,15 +31,17 @@
 	    </f:entry>
 		        
 	    <f:entry title="${%label.folder}" field="folder">
-	        <f:textbox placeholder="${%folder.placeholder}" 
+	        <f:textbox placeholder="${%folder.placeholder}"
+             data-maxsuggestions="99999"
 	         style="background: white url('${resURL}${%search.icon.url}') no-repeat 99% center;
              background-size: 16px;" />
 	    </f:entry>
 	    
 	    <f:entry title="${%label.application}" field="application">
-	        <f:textbox placeholder="${%application.placeholder}" 
-	        style="background: white url('${resURL}${%search.icon.url}') no-repeat 99% center;
-            background-size: 16px;" />
+	        <f:textbox placeholder="${%application.placeholder}"
+             data-maxsuggestions="99999"
+             style="background: white url('${resURL}${%search.icon.url}') no-repeat 99% center;
+             background-size: 16px;" />
 	    </f:entry>
   
 	    <f:entry title="${%label.test.policy}" field="testPolicy">

--- a/src/main/webapp/js/util.js
+++ b/src/main/webapp/js/util.js
@@ -88,20 +88,22 @@ function aseWaitClicked(e) {
 	}
 }
 
-/*
-   * Overridable method called before autocomplete container is loaded with result data.
-   * This method is overridden to dynamically change the autocomplete result list size
-   * @param sQuery {String} Original request.
-   * @param oResponse {Object} Response object.
-   * @param oPayload {MIXED} (optional) Additional argument(s)
-   * @return {Boolean} Return true to continue loading data, false to cancel.
-
-*/
-YAHOO.widget.AutoComplete.prototype.doBeforeLoadData = function (sQuery, oResponse, oPayload) {
-     if (oResponse.results.length != 0) {
-          YAHOO.widget.AutoComplete.prototype.maxResultsDisplayed = oResponse.results.length;
-     }
-     return true;
+if (window.YAHOO) {
+  /*
+     * Fix for the YUI-based autocomplete field, not needed since Jenkins 2.473.
+     * Overridable method called before autocomplete container is loaded with result data.
+     * This method is overridden to dynamically change the autocomplete result list size
+     * @param sQuery {String} Original request.
+     * @param oResponse {Object} Response object.
+     * @param oPayload {MIXED} (optional) Additional argument(s)
+     * @return {Boolean} Return true to continue loading data, false to cancel.
+  */
+  YAHOO.widget.AutoComplete.prototype.doBeforeLoadData = function (sQuery, oResponse, oPayload) {
+       if (oResponse.results.length != 0) {
+            YAHOO.widget.AutoComplete.prototype.maxResultsDisplayed = oResponse.results.length;
+       }
+       return true;
+  }
 }
 
 function resetFields(credentialElement) {


### PR DESCRIPTION
This plugin customized autocomplete text fields that have been replaced in Jenkins 2.473 as part of larger effort to remove the YUI library from Jenkins (see https://issues.jenkins.io/browse/JENKINS-73539).
The new autocomple text fields will support the same customization when https://github.com/jenkinsci/jenkins/pull/9616 is merged.

This PR makes sure the plugin will still work with YUI removed and that the right number of suggestions will be shown in new versions of Jenkins.

### Testing done

None, I don't have any account for AppScan. I would appreciate if the maintainers would check  that autocomplete fields still work properly.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
