### PR TITLE
Fix casing of ASoCCredentials.getAcceptInvalidCerts() for configuration as code compatibility

### DIFF
--- a/src/main/java/com/hcl/appscan/jenkins/plugin/auth/ASoCCredentials.java
+++ b/src/main/java/com/hcl/appscan/jenkins/plugin/auth/ASoCCredentials.java
@@ -47,7 +47,7 @@ public class ASoCCredentials extends UsernamePasswordCredentialsImpl {
 		return m_url;
 	}
 
-        public boolean getacceptInvalidCerts() {return m_acceptInvalidCerts;}
+        public boolean getAcceptInvalidCerts() {return m_acceptInvalidCerts;}
 	
 	public String getServer() {
 		String url = m_url;

--- a/src/main/java/com/hcl/appscan/jenkins/plugin/auth/JenkinsAuthenticationProvider.java
+++ b/src/main/java/com/hcl/appscan/jenkins/plugin/auth/JenkinsAuthenticationProvider.java
@@ -121,6 +121,6 @@ public class JenkinsAuthenticationProvider implements IAuthenticationProvider, S
 
     	@Override
     	public boolean getacceptInvalidCerts() {
-        	return m_credentials.getacceptInvalidCerts();
+        	return m_credentials.getAcceptInvalidCerts();
     	}
 }


### PR DESCRIPTION
Configuration as Code does not work since the getter ASoCCredentials.get**a**cceptInvalidCerts() is misspelled and the configuration fails.
Simply fixing the casing makes it work.

### Testing done

I've tested locally and CasC works now on my machine.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
