### PR TITLE
ASA 10264

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
 
   <properties>
         <slf4jVersion>1.7.26</slf4jVersion>
-        <jenkins.baseline>2.414</jenkins.baseline>
+        <jenkins.baseline>2.426</jenkins.baseline>
         <jenkins.version>${jenkins.baseline}.3</jenkins.version>
         <findbugs.failOnError>false</findbugs.failOnError>
         <spotbugs.failOnError>false</spotbugs.failOnError>

--- a/pom.xml
+++ b/pom.xml
@@ -27,14 +27,14 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.2</version>
+    <version>4.52</version>
     <relativePath />
   </parent>
 
   <properties>
         <slf4jVersion>1.7.26</slf4jVersion>
-        <java.level>8</java.level>
-	<jenkins.version>2.222.4</jenkins.version>
+        <jenkins.baseline>2.361</jenkins.baseline>
+        <jenkins.version>${jenkins.baseline}.1</jenkins.version>
 	<findbugs.failOnError>false</findbugs.failOnError>
   </properties>
 	
@@ -43,6 +43,17 @@
   <version>1.5.2-SNAPSHOT</version>
   <description>This plugin allows you to execute security scans with HCL AppScan</description>
   <packaging>hpi</packaging>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.jenkins.tools.bom</groupId>
+                <artifactId>bom-${jenkins.baseline}.x</artifactId>
+                <version>2102.v854b_fec19c92</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
   <repositories>
     	<repository>
@@ -63,7 +74,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.5.1</version>
         <configuration>
           <source>1.7</source>
           <target>1.7</target>

--- a/pom.xml
+++ b/pom.xml
@@ -33,8 +33,8 @@
 
   <properties>
         <slf4jVersion>1.7.26</slf4jVersion>
-        <jenkins.baseline>2.361</jenkins.baseline>
-        <jenkins.version>${jenkins.baseline}.1</jenkins.version>
+        <jenkins.baseline>2.414</jenkins.baseline>
+        <jenkins.version>${jenkins.baseline}.3</jenkins.version>
         <findbugs.failOnError>false</findbugs.failOnError>
         <spotbugs.failOnError>false</spotbugs.failOnError>
   </properties>
@@ -49,7 +49,7 @@
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
                 <artifactId>bom-${jenkins.baseline}.x</artifactId>
-                <version>2102.v854b_fec19c92</version>
+                <version>2718.v7e8a_d43b_3f0b_</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -102,7 +102,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>credentials</artifactId>
-            <version>2.6.1.1</version>
+            <version>1319.v7eb_51b_3a_c97b_</version>
         </dependency>
   </dependencies>
   

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,8 @@
         <slf4jVersion>1.7.26</slf4jVersion>
         <jenkins.baseline>2.361</jenkins.baseline>
         <jenkins.version>${jenkins.baseline}.1</jenkins.version>
-	<findbugs.failOnError>false</findbugs.failOnError>
+        <findbugs.failOnError>false</findbugs.failOnError>
+        <spotbugs.failOnError>false</spotbugs.failOnError>
   </properties>
 	
   <groupId>com.hcl.security</groupId>

--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -1,0 +1,4 @@
+<?jelly escape-by-default='true'?>
+<div>
+    This plugin allows you to execute security scans with HCL AppScan
+</div>


### PR DESCRIPTION
We have updated the minimum required Java version for building the Jenkins plugin to Java 11 and also made the minimum required Jenkins version 2.426.3 for our plugin.