### PR TITLE
Migrate StringEscapeUtils from Commons Lang 2 to Commons Text

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,6 +88,10 @@
   </build>
   
   <dependencies>
+        <dependency>
+            <groupId>io.jenkins.plugins</groupId>
+            <artifactId>commons-text-api</artifactId>
+        </dependency>
 	<dependency>
 		<groupId>com.hcl</groupId>
 		<artifactId>appscan.sdk</artifactId>

--- a/src/main/java/com/hcl/appscan/jenkins/plugin/builders/AppScanEnterpriseBuildStep.java
+++ b/src/main/java/com/hcl/appscan/jenkins/plugin/builders/AppScanEnterpriseBuildStep.java
@@ -21,7 +21,7 @@ import java.util.Map.Entry;
 import java.util.Set;
 import java.util.concurrent.ThreadLocalRandom;
 
-import org.apache.commons.lang.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 import org.jenkinsci.Symbol;
 import org.jenkinsci.remoting.RoleChecker;
 import org.kohsuke.stapler.AncestorInPath;
@@ -175,7 +175,7 @@ public class AppScanEnterpriseBuildStep extends Builder implements SimpleBuildSt
 		// configuration. 
 		if (getDescriptor().folderMap != null &&
 				getDescriptor().folderMap.get(m_folder) != null) {
-			String folder = StringEscapeUtils.unescapeHtml(
+			String folder = StringEscapeUtils.unescapeHtml4(
 					getDescriptor().folderMap.get(m_folder));
 			return folder;
 		}
@@ -192,7 +192,7 @@ public class AppScanEnterpriseBuildStep extends Builder implements SimpleBuildSt
 		// configuration. 
 		if (getDescriptor().templateMap != null &&
 				getDescriptor().templateMap.get(m_template) != null) {
-        	String template = StringEscapeUtils.unescapeHtml(
+        	String template = StringEscapeUtils.unescapeHtml4(
         			getDescriptor().templateMap.get(m_template));
         	return template;
 		}
@@ -217,7 +217,7 @@ public class AppScanEnterpriseBuildStep extends Builder implements SimpleBuildSt
 		// configuration. 
 		if (getDescriptor().applicationMap != null &&
 				getDescriptor().applicationMap.get(m_application) != null) {
-			String appName = StringEscapeUtils.unescapeHtml(
+			String appName = StringEscapeUtils.unescapeHtml4(
 					getDescriptor().applicationMap.get(m_application));
 			return appName;
 		}
@@ -475,7 +475,7 @@ public class AppScanEnterpriseBuildStep extends Builder implements SimpleBuildSt
     	private String getUpdatedApplicationId(Map<String, String> application){
         	if(application != null) {
             	for(Map.Entry<String, String> entry : application.entrySet()){
-                	String appName = StringEscapeUtils.unescapeHtml(entry.getValue());
+                	String appName = StringEscapeUtils.unescapeHtml4(entry.getValue());
                 	if(appName != null && appName.equals(m_application)) {
                     	return entry.getKey();
                 		}
@@ -645,7 +645,7 @@ public class AppScanEnterpriseBuildStep extends Builder implements SimpleBuildSt
 			AutoCompletionCandidates model = new AutoCompletionCandidates();
 			if (sortedApplicationList != null) {
 				for(Map.Entry<String, String> entry : sortedApplicationList) {
-					String appName = StringEscapeUtils.unescapeHtml(entry.getValue());
+					String appName = StringEscapeUtils.unescapeHtml4(entry.getValue());
 					if (value.equals(SHOW_ALL)) {
 						model.add(appName);
 					}
@@ -664,7 +664,7 @@ public class AppScanEnterpriseBuildStep extends Builder implements SimpleBuildSt
 			AutoCompletionCandidates model = new AutoCompletionCandidates();
 			if (sortedFolderList != null) {
 				for(Map.Entry<String, String> entry : sortedFolderList) {
-					String folderName = StringEscapeUtils.unescapeHtml(entry.getValue());
+					String folderName = StringEscapeUtils.unescapeHtml4(entry.getValue());
 					if (value.equals(SHOW_ALL)) {
 						model.add(folderName);
 					}
@@ -701,7 +701,7 @@ public class AppScanEnterpriseBuildStep extends Builder implements SimpleBuildSt
 			AutoCompletionCandidates model = new AutoCompletionCandidates();
 			if (sortedTemplateList != null) {
 				for(Map.Entry<String, String> entry : sortedTemplateList) {
-					String templateName = StringEscapeUtils.unescapeHtml(entry.getValue());
+					String templateName = StringEscapeUtils.unescapeHtml4(entry.getValue());
 					if (value.equals(SHOW_ALL)) {
 						model.add(templateName);
 					}
@@ -794,7 +794,7 @@ public class AppScanEnterpriseBuildStep extends Builder implements SimpleBuildSt
 		private String getApplicationId(String application) {
 			if (sortedApplicationList != null) {
 				for(Map.Entry<String, String> entry : sortedApplicationList) {
-					String appName = StringEscapeUtils.unescapeHtml(entry.getValue());
+					String appName = StringEscapeUtils.unescapeHtml4(entry.getValue());
 					if (appName != null && appName.equals(application)) {
 						return entry.getKey();
 					}
@@ -812,7 +812,7 @@ public class AppScanEnterpriseBuildStep extends Builder implements SimpleBuildSt
 		private String getFolderId(String folder) {
 			if (sortedFolderList != null) {
 				for(Map.Entry<String, String> entry : sortedFolderList) {
-					String folderName = StringEscapeUtils.unescapeHtml(entry.getValue());
+					String folderName = StringEscapeUtils.unescapeHtml4(entry.getValue());
 					if(folderName != null && folderName.equals(folder)) {
 						return entry.getKey();
 					}
@@ -830,7 +830,7 @@ public class AppScanEnterpriseBuildStep extends Builder implements SimpleBuildSt
 		private String getTemplateId(String template) {
 			if (sortedTemplateList != null) {
 				for(Map.Entry<String, String> entry : sortedTemplateList) {
-					String templateName = StringEscapeUtils.unescapeHtml(entry.getValue());
+					String templateName = StringEscapeUtils.unescapeHtml4(entry.getValue());
 					if(templateName != null && templateName.equals(template)) {
 						return entry.getKey();
 					}


### PR DESCRIPTION
Migrate from deprecated/EOL Commons Lang 2 to Commons Text.

Part of the effort to remove Commons Lang 2 from Jenkins core — jenkinsci/jenkins#16404,
jenkinsci/jenkins#26105. Commons Lang 2 is EOL and carries an unfixed advisory
(GHSA-j288-q9x7-2f5v).

`StringEscapeUtils` is used in 10 places in `AppScanEnterpriseBuildStep`. It moves to Commons
Text (`commons-text-api`) rather than Commons Lang 3, because `org.apache.commons.lang3.StringEscapeUtils`
is itself deprecated — credentials-plugin needed a second PR (#644) to undo exactly that mistake.

`unescapeHtml` becomes `unescapeHtml4`, which is the Commons Text name for the same HTML 4.0
entity set that Commons Lang 2 unescaped.

### Testing done

`mvn -B -ntp clean verify` passes locally on Java 21 / macOS.
The `ban-commons-lang-2` enforcer rule was left disabled because it needs parent POM
`6.2116.v7501b_67dc517` or newer; bumping the parent from `5.9` pulls in the Jakarta EE 9
migration, which is out of scope for this change.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

---

🤖 This pull request was generated with AI assistance (Claude Code) as part of a bulk migration
across Jenkins plugins. If anything here looks wrong, please comment on this PR or contact
@parameter.
